### PR TITLE
Update FAQ with grammar fix and adding github URL

### DIFF
--- a/overtrack_web/templates/faq.html
+++ b/overtrack_web/templates/faq.html
@@ -45,7 +45,10 @@
                                 <a class="nav-link" href="#dll">I'm getting <code>DLL load failed</code></a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" href="#perf">How can I improve performance while using OverTrack</a>
+                                <a class="nav-link" href="#perf">How can I improve performance while using OverTrack?</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="#github">How can I contribute to OverTrack's development?</a>
                             </li>
                         </ul>
                     </div>
@@ -164,7 +167,7 @@
                                     <a href="https://aka.ms/vs/16/release/vc_redist.x64.exe">https://aka.ms/vs/16/release/vc_redist.x64.exe</a>
                                 </p>
                             </dd>
-                            <dt id="perf"><h2>How can I improve performance while using OverTrack</h2></dt>
+                            <dt id="perf"><h2>How can I improve performance while using OverTrack?</h2></dt>
                             <dd>
                                 <p>To minimize the performance impact (e.g. to reduce FPS stutter, lag, and lost FPS) of
                                     OverTrack you can try the following
@@ -184,6 +187,13 @@
                                     Menu\Programs\Startup</code> to have the target <code>C:\Windows\System32\cmd.exe /C
                                     START /BELOWNORMAL /AFFINITY 0x1 /D "%appdata%/overtrack/"
                                     overtrack_launcher.exe</code>
+                                </p>
+                            </dd>
+                            <dt id="github"><h2>How can I contribute to OverTrack's development?</h2></dt>
+                            <dd>
+                                <p>
+                                    To contribute to OverTrack's development costs, you can {{ url_for('subscribe') }}. Alternatively, you can contribute
+                                    new features, bug fixes and issues to our <a href="https://github.com/overtrack-gg/overtrack-web-2">GitHub repo</a>. 
                                 </p>
                             </dd>
                         </dl>


### PR DESCRIPTION
This fixes https://github.com/overtrack-gg/overtrack-web-2/issues/42. 

Also adds a ? onto the title of `How can I improve performance while using OverTrack` to make it grammatically correct. 😛