### PR TITLE
Fix the FAQ page to handle Valorant correctly

### DIFF
--- a/overtrack_web/overtrack_web/flask_app.py
+++ b/overtrack_web/overtrack_web/flask_app.py
@@ -316,7 +316,7 @@ def faq():
     game = request.args.get('game')
     return render_template(
         'faq.html',
-        game_name=game if game in ['overwatch', 'apex'] else None
+        game_name=game if game in ['overwatch', 'apex', 'valorant'] else None
     )
 
 


### PR DESCRIPTION
Should I also add an FAQ entry for Valorant not tracking correctly? I didn't want to add an `is_valorant` variable until we had a use for it, but can do if preferred just for consistency.